### PR TITLE
add: homepage to project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ description = "Python bindings for heck, the Rust case conversion library"
 authors = [ {name = "kevinheavey", email = "kevinheavey123@gmail.com"} ]
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
+homepage = "https://github.com/kevinheavey/pyheck"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
So you can easily navigate from `pypi.org` to `github`